### PR TITLE
Add support for TokenLifetime(TimeSpan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 *.user
 *.suo
+*.ncrunchsolution
 /_ReSharper.FluentACS
 /FluentACS/_ReSharper.FluentACS
 /FluentACS/bin

--- a/FluentACS/Specs/RelyingPartySpec.cs
+++ b/FluentACS/Specs/RelyingPartySpec.cs
@@ -156,6 +156,12 @@
             return this;
         }
 
+        public RelyingPartySpec TokenLifetime(TimeSpan tokenLifetime)
+        {
+            this.tokenLifetime = Convert.ToInt32(tokenLifetime.TotalSeconds);
+            return this;
+        }
+
         internal IEnumerable<string> AllowedIdentityProviders()
         {
             return this.allowedIdentityProviders;

--- a/FluentACSTest/App.config
+++ b/FluentACSTest/App.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <appSettings>
-        <add key="acsNamespace" value="somenamespace"/>
+        <add key="acsNamespace" value="fluentacsd6"/>
         <add key="acsUserName" value="ManagementClient"/>
-        <add key="acsPassword" value="T+bQtqP21BaCLO/8D1hanRdKJF8ZYEV8t32odxP4pYk="/>
+        <add key="acsPassword" value="WBI6j+fRYIWiiVMImZllDGqVh9NIDfcnjrdHJTvsQLg="/>
     </appSettings>
 </configuration>


### PR DESCRIPTION
I find that when representing times in .NET it is clearer to represent them using the TimeSpan object, thus I have created an overload for TokenLifetime that takes a TimeSpan rather than an int.

I also excluded .ncrunchsolution for the few people who use NCrunch.
