### PR TITLE
Add support for Service Identities with X509Certificates and Facebook Identity Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.user
 *.suo
 *.ncrunchsolution
+*.DotSettings
 /_ReSharper.FluentACS
 /FluentACS/_ReSharper.FluentACS
 /FluentACS/bin
@@ -14,3 +15,4 @@
 /SampleApp/obj
 /SampleApp/app.config.private
 /SampleApp/app.config.repo
+/TestResults

--- a/FluentACS/AcsNamespace.cs
+++ b/FluentACS/AcsNamespace.cs
@@ -46,6 +46,18 @@
             return this;
         }
 
+        public AcsNamespace AddServiceIdentityWithX509Certificate(Action<ServiceIdentityWithX509CertificateSpec> configAction)
+        {
+            Guard.NotNull(() => configAction, configAction);
+
+            var spec = new ServiceIdentityWithX509CertificateSpec();
+            configAction(spec);
+
+            this.commands.Add(new AddServiceIdentityWithX509CertificateCommand(spec));
+
+            return this;
+        }
+
         public AcsNamespace AddRelyingParty(Action<RelyingPartySpec> configAction)
         {
             Guard.NotNull(() => configAction, configAction);

--- a/FluentACS/AcsNamespace.cs
+++ b/FluentACS/AcsNamespace.cs
@@ -34,6 +34,18 @@
             return this;
         }
 
+        public AcsNamespace AddFacebookIdentityProvider(Action<FacebookIdentityProviderSpec> configAction)
+        {
+            Guard.NotNull(() => configAction, configAction);
+
+            var spec = new FacebookIdentityProviderSpec();
+            configAction(spec);
+
+            this.commands.Add(new AddIdentityProviderCommand(spec));
+
+            return this;
+        }
+
         public AcsNamespace AddServiceIdentity(Action<ServiceIdentitySpec> configAction)
         {
             Guard.NotNull(() => configAction, configAction);

--- a/FluentACS/Commands/AddIdentityProviderCommand.cs
+++ b/FluentACS/Commands/AddIdentityProviderCommand.cs
@@ -20,6 +20,12 @@
 
         public override void Execute(object receiver, Action<LogInfo> logAction)
         {
+            // AddIdentityProviderCommand has branches for each of
+            // the spec types. At present this is at the limit of its
+            // scalability;
+            
+            // TODO: consider refactoring to reduce the cyclomatic complexity of the Execute method.
+
             var acsWrapper = (ServiceManagementWrapper)receiver;
 
             var idpToRemove = acsWrapper.RetrieveIdentityProviders().Where(idp => idp.DisplayName.Equals(this.identityProviderSpec.DisplayName())).SingleOrDefault();

--- a/FluentACS/Commands/AddIdentityProviderCommand.cs
+++ b/FluentACS/Commands/AddIdentityProviderCommand.cs
@@ -43,6 +43,16 @@
                 acsWrapper.AddYahooIdentityProvider();
                 this.LogSavingChangesMessage(logAction);
             }
+
+            if (this.identityProviderSpec is FacebookIdentityProviderSpec)
+            {
+                var facebookIdentityProviderSpec = (FacebookIdentityProviderSpec)identityProviderSpec;
+                this.LogMessage(logAction, string.Format("Adding Identity Provider '{0}'", facebookIdentityProviderSpec.DisplayName()));
+                acsWrapper.AddFacebookIdentityProvider(facebookIdentityProviderSpec.DisplayName(),
+                    facebookIdentityProviderSpec.AppId(), 
+                    facebookIdentityProviderSpec.AppSecret());
+                this.LogSavingChangesMessage(logAction);
+            }
         }
     }
 }

--- a/FluentACS/Commands/AddIdentityProviderCommand.cs
+++ b/FluentACS/Commands/AddIdentityProviderCommand.cs
@@ -56,7 +56,8 @@
                 this.LogMessage(logAction, string.Format("Adding Identity Provider '{0}'", facebookIdentityProviderSpec.DisplayName()));
                 acsWrapper.AddFacebookIdentityProvider(facebookIdentityProviderSpec.DisplayName(),
                     facebookIdentityProviderSpec.AppId(), 
-                    facebookIdentityProviderSpec.AppSecret());
+                    facebookIdentityProviderSpec.AppSecret(),
+                    facebookIdentityProviderSpec.ApplicationPermissions());
                 this.LogSavingChangesMessage(logAction);
             }
         }

--- a/FluentACS/Commands/AddServiceIdentityWithX509CertificateCommand.cs
+++ b/FluentACS/Commands/AddServiceIdentityWithX509CertificateCommand.cs
@@ -22,7 +22,7 @@ namespace FluentACS.Commands
         {
             var acsWrapper = (ServiceManagementWrapper)receiver;
 
-            var sidToRemove = acsWrapper.RetrieveServiceIdentities().Where(si => si.Name.Equals(this.serviceIdentityWithX509Spec.Name())).SingleOrDefault();
+            var sidToRemove = acsWrapper.RetrieveServiceIdentities().SingleOrDefault(si => si.Name.Equals(this.serviceIdentityWithX509Spec.Name()));
             if (sidToRemove != null)
             {
                 this.LogMessage(logAction, string.Format("Removing Service Identity '{0}'", sidToRemove.Name));
@@ -31,7 +31,7 @@ namespace FluentACS.Commands
             }
 
             this.LogMessage(logAction, string.Format("Adding Service Identity '{0}'", this.serviceIdentityWithX509Spec.Name()));
-            acsWrapper.AddServiceIdentityWithCertificate(this.serviceIdentityWithX509Spec.Name(), this.serviceIdentityWithX509Spec.EncryptionCertificate(), this.serviceIdentityWithX509Spec.StartDate(), this.serviceIdentityWithX509Spec.EndDate());
+            acsWrapper.AddServiceIdentityWithCertificate(this.serviceIdentityWithX509Spec.Name(), this.serviceIdentityWithX509Spec.Certificates());
             this.LogSavingChangesMessage(logAction);
         }
     }

--- a/FluentACS/Commands/AddServiceIdentityWithX509CertificateCommand.cs
+++ b/FluentACS/Commands/AddServiceIdentityWithX509CertificateCommand.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+
+using FluentACS.Logging;
+using FluentACS.ManagementService;
+using FluentACS.Specs;
+
+namespace FluentACS.Commands
+{
+    public class AddServiceIdentityWithX509CertificateCommand : BaseCommand
+    {
+        private readonly ServiceIdentityWithX509CertificateSpec serviceIdentityWithX509Spec;
+
+        public AddServiceIdentityWithX509CertificateCommand(ServiceIdentityWithX509CertificateSpec serviceIdentityWithX509Spec)
+        {
+            Guard.NotNull(() => serviceIdentityWithX509Spec, serviceIdentityWithX509Spec);
+
+            this.serviceIdentityWithX509Spec = serviceIdentityWithX509Spec;
+        }
+
+        public override void Execute(object receiver, Action<LogInfo> logAction)
+        {
+            var acsWrapper = (ServiceManagementWrapper)receiver;
+
+            var sidToRemove = acsWrapper.RetrieveServiceIdentities().Where(si => si.Name.Equals(this.serviceIdentityWithX509Spec.Name())).SingleOrDefault();
+            if (sidToRemove != null)
+            {
+                this.LogMessage(logAction, string.Format("Removing Service Identity '{0}'", sidToRemove.Name));
+                acsWrapper.RemoveServiceIdentity(sidToRemove.Name);
+                this.LogSavingChangesMessage(logAction);
+            }
+
+            this.LogMessage(logAction, string.Format("Adding Service Identity '{0}'", this.serviceIdentityWithX509Spec.Name()));
+            acsWrapper.AddServiceIdentityWithCertificate(this.serviceIdentityWithX509Spec.Name(), this.serviceIdentityWithX509Spec.EncryptionCertificate(), this.serviceIdentityWithX509Spec.StartDate(), this.serviceIdentityWithX509Spec.EndDate());
+            this.LogSavingChangesMessage(logAction);
+        }
+    }
+}

--- a/FluentACS/FluentACS.csproj
+++ b/FluentACS/FluentACS.csproj
@@ -77,6 +77,7 @@
       <DependentUpon>Reference.datasvcmap</DependentUpon>
     </Compile>
     <Compile Include="Specs\BaseSpec.cs" />
+    <Compile Include="Specs\FacebookApplicationPermission.cs" />
     <Compile Include="Specs\FacebookIdentityProviderSpec.cs" />
     <Compile Include="Specs\GoogleIdentityProviderSpec.cs" />
     <Compile Include="Specs\IdentityProviderConsts.cs" />

--- a/FluentACS/FluentACS.csproj
+++ b/FluentACS/FluentACS.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Specs\ServiceIdentityWithX509CertificateSpec.cs" />
     <Compile Include="Specs\ServiceIdentitySpec.cs" />
     <Compile Include="Specs\SigningCertificateSpec.cs" />
+    <Compile Include="Specs\X509CertificateHelper.cs" />
     <Compile Include="Specs\YahooIdentityProviderSpec.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/FluentACS/FluentACS.csproj
+++ b/FluentACS/FluentACS.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Commands\AddRuleCommand.cs" />
     <Compile Include="Commands\AddRuleGroupCommand.cs" />
     <Compile Include="Commands\AddServiceIdentityCommand.cs" />
+    <Compile Include="Commands\AddServiceIdentityWithX509CertificateCommand.cs" />
     <Compile Include="Commands\BaseCommand.cs" />
     <Compile Include="Commands\ICommand.cs" />
     <Compile Include="Logging\LogInfo.cs" />
@@ -94,6 +95,7 @@
     <Compile Include="Specs\Rules\OutputClaimTypeSpec.cs" />
     <Compile Include="Specs\Rules\OutputClaimValueSpec.cs" />
     <Compile Include="Specs\Rules\RuleSpec.cs" />
+    <Compile Include="Specs\ServiceIdentityWithX509CertificateSpec.cs" />
     <Compile Include="Specs\ServiceIdentitySpec.cs" />
     <Compile Include="Specs\SigningCertificateSpec.cs" />
     <Compile Include="Specs\YahooIdentityProviderSpec.cs" />

--- a/FluentACS/FluentACS.csproj
+++ b/FluentACS/FluentACS.csproj
@@ -77,6 +77,7 @@
       <DependentUpon>Reference.datasvcmap</DependentUpon>
     </Compile>
     <Compile Include="Specs\BaseSpec.cs" />
+    <Compile Include="Specs\FacebookIdentityProviderSpec.cs" />
     <Compile Include="Specs\GoogleIdentityProviderSpec.cs" />
     <Compile Include="Specs\IdentityProviderConsts.cs" />
     <Compile Include="Specs\IdentityProviderSpec.cs" />

--- a/FluentACS/Guard.cs
+++ b/FluentACS/Guard.cs
@@ -34,6 +34,7 @@ namespace FluentACS
 {
     using System;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq.Expressions;
 
     /// <summary>
@@ -62,6 +63,12 @@ namespace FluentACS
             NotNull<string>(reference, value);
             if (value.Length == 0)
                 throw new ArgumentException(GetParameterName(reference), "Parameter cannot be empty.");
+        }
+
+        public static void FileExists(Expression<Func<string>> reference, string value)
+        {
+            if (!File.Exists(value))
+                throw new ArgumentException(GetParameterName(reference), "Parameter must be a path to an existing file.");                
         }
 
         private static string GetParameterName(Expression reference)

--- a/FluentACS/ManagementService/ServiceManagementWrapper.cs
+++ b/FluentACS/ManagementService/ServiceManagementWrapper.cs
@@ -20,7 +20,6 @@ namespace FluentACS.ManagementService
         private readonly string serviceIdentityUsernameForManagement;
         private readonly string serviceNamespace;
         private static string cachedSwtToken;
-        //private ManagementService managementService;
 
         public ServiceManagementWrapper(string serviceNamespace, string serviceIdentityUsernameForManagement, string serviceIdentityPasswordForManagement)
         {
@@ -1080,6 +1079,36 @@ namespace FluentACS.ManagementService
             }
         }
 
+        public void AddServiceIdentityWithCertificate(string name, byte[] encryptionCert, DateTime startdate, DateTime enddate)
+        {
+            try
+            {
+                var client = CreateManagementServiceClient();
+                var serviceIdentity = new ServiceIdentity
+                {
+                    Name = name
+                };
+
+                client.AddToServiceIdentities(serviceIdentity);
+
+                var serviceIdentityKey = new ServiceIdentityKey
+                {
+                    DisplayName = "Credentials for " + name,
+                    Type = IdentityKeyTypes.X509Certificate.ToString(),
+                    Usage = IdentityKeyUsages.Signing.ToString(),
+                    Value = encryptionCert,
+                    StartDate = startdate,
+                    EndDate = enddate
+                };
+
+                client.AddRelatedObject(serviceIdentity, "ServiceIdentityKeys", serviceIdentityKey);
+                client.SaveChanges(SaveChangesOptions.Batch);
+            }
+            catch (Exception ex)
+            {
+                throw TryGetExceptionDetails(ex);
+            }
+        }
 
         [DataContract]
         private class OAuth2TokenResponse

--- a/FluentACS/ManagementService/ServiceManagementWrapper.cs
+++ b/FluentACS/ManagementService/ServiceManagementWrapper.cs
@@ -30,6 +30,11 @@ namespace FluentACS.ManagementService
 
         public Issuer AddFacebookIdentityProvider(string displayName, string facebookAppId, string facebookAppSecret)
         {
+            return AddFacebookIdentityProvider(displayName, facebookAppId, facebookAppSecret, new [] { "email" });
+        }
+
+        public Issuer AddFacebookIdentityProvider(string displayName, string facebookAppId, string facebookAppSecret, string[] loginParameters)
+        {
             try
             {
                 var client = this.CreateManagementServiceClient();
@@ -46,7 +51,7 @@ namespace FluentACS.ManagementService
                                    {
                                        DisplayName = displayName, 
                                        LoginLinkName = "Facebook", 
-                                       LoginParameters = "email", 
+                                       LoginParameters = String.Join(",", loginParameters), 
                                        WebSSOProtocolType = WebSSOProtocolType.Facebook.ToString(), 
                                        IssuerId = issuer.Id
                                    };

--- a/FluentACS/Specs/FacebookApplicationPermission.cs
+++ b/FluentACS/Specs/FacebookApplicationPermission.cs
@@ -1,0 +1,412 @@
+﻿namespace FluentACS.Specs
+{
+    public static class FacebookApplicationPermission
+    {
+
+        #region Email Permissions
+        
+        /// <summary>
+        /// Provides access to the user's primary email address in the email property. Do not spam users. Your use of email must comply both with Facebook policies and with the CAN-SPAM Act.
+        /// </summary>
+        public const string Email = "email";
+
+        #endregion
+
+
+        #region Extended Permissions
+
+        /// <summary>
+        /// Provides access to any friend lists the user created. All user's friends are provided as part of basic data, this extended permission grants access to the lists of friends a user has created, and should only be requested if your application utilizes lists of friends.
+        /// </summary>
+        public const string ReadFriendlists = "read_friendlists";
+
+        /// <summary>
+        /// Provides read access to the Insights data for pages, applications, and domains the user owns.
+        /// </summary>
+        public const string ReadInsights = "read_insights";
+
+        /// <summary>
+        /// Provides the ability to read from a user's Facebook Inbox.
+        /// </summary>
+        public const string ReadMailbox = "read_mailbox";
+
+        /// <summary>
+        /// Provides read access to the user's friend requests
+        /// </summary>
+        public const string ReadRequests = "read_requests";
+
+        /// <summary>
+        /// Provides access to all the posts in the user's News Feed and enables your application to perform searches against the user's News Feed
+        /// </summary>
+        public const string ReadStream = "read_stream";
+
+        /// <summary>
+        /// Provides applications that integrate with Facebook Chat the ability to log in users.
+        /// </summary>
+        public const string XmppLogin = "xmpp_login";
+
+        /// <summary>
+        /// Provides the ability to manage ads and call the Facebook Ads API on behalf of a user.
+        /// </summary>
+        public const string AdsManagement = "ads_management";
+
+        /// <summary>
+        /// Enables your application to create and modify events on the user's behalf
+        /// </summary>
+        public const string CreateEvent = "create_event";
+
+        /// <summary>
+        /// Enables your app to create and edit the user's friend lists.
+        /// </summary>
+        public const string ManageFriendlists = "manage_friendlists";
+
+        /// <summary>
+        /// Enables your app to read notifications and mark them as read. Intended usage: This permission should be used to let users read and act on their notifications; it should not be used to for the purposes of modeling user behavior or data mining. Apps that misuse this permission may be banned from requesting it.
+        /// </summary>
+        public const string ManageNotifications = "manage_notifications";
+
+        /// <summary>
+        /// Provides access to the user's online/offline presence
+        /// </summary>
+        public const string UserOnlinePresence = "user_online_presence";
+
+        /// <summary>
+        /// Provides access to the user's friend's online/offline presence
+        /// </summary>
+        public const string FriendsOnlinePresense = "friends_online_presence";
+
+        /// <summary>
+        /// Enables your app to perform checkins on behalf of the user.
+        /// </summary>
+        public const string PublishCheckins = "publish_checkins";
+
+        /// <summary>
+        /// Enables your app to post content, comments, and likes to a user's stream and to the streams of the user's friends. This is a superset publishing permission which also includes publish_actions. However, please note that Facebook recommends a user-initiated sharing model. Please read the Platform Policies to ensure you understand how to properly use this permission. Note, you do not need to request the publish_stream permission in order to use the Feed Dialog, the Requests Dialog or the Send Dialog.
+        /// </summary>
+        public const string PublishStream = "publish_stream";
+
+        /// <summary>
+        /// Enables your application to RSVP to events on the user's behalf
+        /// </summary>
+        public const string RsvpEvent = "rsvp_event";
+
+        #endregion
+
+
+        #region Extended Profile Properties (User)
+
+        /// <summary>
+        /// Provides access to the About Me section of the profile in the about property
+        /// </summary>
+        public const string UserAboutMe = "user_about_me";
+
+        /// <summary>
+        /// Provides access to the user's list of activities as the activities connection
+        /// </summary>
+        public const string UserActivities = "user_activities";
+
+        /// <summary>
+        /// Provides access to the birthday with year as the birthday property
+        /// </summary>
+        public const string UserBirthday = "user_birthday";
+
+        /// <summary>
+        /// Provides read access to the authorized user's check-ins or a friend's check-ins that the user can see. This permission is superseded by user_status for new applications as of March, 2012.
+        /// </summary>
+        public const string UserCheckins = "user_checkins";
+
+        /// <summary>
+        /// Provides access to education history as the education property
+        /// </summary>
+        public const string UserEducationHistory = "user_education_history";
+
+        /// <summary>
+        /// Provides access to the list of events the user is attending as the events connection
+        /// </summary>
+        public const string UserEvents = "user_events";
+
+        /// <summary>
+        /// Provides access to the list of groups the user is a member of as the groups connection
+        /// </summary>
+        public const string UserGroups = "user_groups";
+
+        /// <summary>
+        /// Provides access to the user's hometown in the hometown property
+        /// </summary>
+        public const string UserHometown = "user_hometown";
+
+        /// <summary>
+        /// Provides access to the user's list of interests as the interests connection
+        /// </summary>
+        public const string UserInterests = "user_interests";
+
+        /// <summary>
+        /// Provides access to the list of all of the pages the user has liked as the likes connection
+        /// </summary>
+        public const string UserLikes = "user_likes";
+
+        /// <summary>
+        /// Provides access to the user's current location as the location property
+        /// </summary>
+        public const string UserLocation = "user_location";
+
+        /// <summary>
+        /// Provides access to the user's notes as the notes connection
+        /// </summary>
+        public const string UserNotes = "user_notes";
+
+        /// <summary>
+        /// Provides access to the photos the user has uploaded, and photos the user has been tagged in
+        /// </summary>
+        public const string UserPhotos = "user_photos";
+
+        /// <summary>
+        /// Provides access to the questions the user or friend has asked
+        /// </summary>
+        public const string UserQuestions = "user_questions";
+
+        /// <summary>
+        /// Provides access to the user's family and personal relationships and relationship status
+        /// </summary>
+        public const string UserRelationships = "user_relationships";
+
+        /// <summary>
+        /// Provides access to the user's relationship preferences
+        /// </summary>
+        public const string UserRelationshipDetails = "user_relationship_details";
+
+        /// <summary>
+        /// Provides access to the user's religious and political affiliations
+        /// </summary>
+        public const string UserReligionPolitics = "user_religion_politics";
+
+        /// <summary>
+        /// Provides access to the user's status messages and checkins. Please see the documentation for the location_post table for information on how this permission may affect retrieval of information about the locations associated with posts.
+        /// </summary>
+        public const string UserStatus = "user_status";
+
+        /// <summary>
+        /// Provides access to the user's subscribers and subscribees
+        /// </summary>
+        public const string UserSubscriptions = "user_subscriptions";
+
+        /// <summary>
+        /// Provides access to the videos the user has uploaded, and videos the user has been tagged in
+        /// </summary>
+        public const string UserVideos = "user_videos";
+
+        /// <summary>
+        /// Provides access to the user's web site URL
+        /// </summary>
+        public const string UserWebsite = "user_website";
+
+        /// <summary>
+        /// Provides access to work history as the work property
+        /// </summary>
+        public const string UserWorkHistory = "user_work_history";
+
+        #endregion
+
+
+        #region Extended Profile Properties (Friends)
+
+        /// <summary>
+        /// Provides access to the About Me section of the profile in the about property
+        /// </summary>
+        public const string FriendsAboutMe = "friends_about_me";
+
+        /// <summary>
+        /// Provides access to the user's list of activities as the activities connection
+        /// </summary>
+        public const string FriendsActivities = "friends_activities";
+
+        /// <summary>
+        /// Provides access to the birthday with year as the birthday property
+        /// </summary>
+        public const string FriendsBirthday = "friends_birthday";
+
+        /// <summary>
+        /// Provides read access to the authorized user's check-ins or a friend's check-ins that the user can see. This permission is superseded by friends_status for new applications as of March, 2012.
+        /// </summary>
+        public const string FriendsCheckins = "friends_checkins";
+
+        /// <summary>
+        /// Provides access to education history as the education property
+        /// </summary>
+        public const string FriendsEducationHistory = "friends_education_history";
+
+        /// <summary>
+        /// Provides access to the list of events the user is attending as the events connection
+        /// </summary>
+        public const string FriendsEvents = "friends_events";
+
+        /// <summary>
+        /// Provides access to the list of groups the user is a member of as the groups connection
+        /// </summary>
+        public const string FriendsGroups = "friends_groups";
+
+        /// <summary>
+        /// Provides access to the user's hometown in the hometown property
+        /// </summary>
+        public const string FriendsHometown = "friends_hometown";
+
+        /// <summary>
+        /// Provides access to the user's list of interests as the interests connection
+        /// </summary>
+        public const string FriendsInterests = "friends_interests";
+
+        /// <summary>
+        /// Provides access to the list of all of the pages the user has liked as the likes connection
+        /// </summary>
+        public const string FriendsLikes = "friends_likes";
+
+        /// <summary>
+        /// Provides access to the user's current location as the location property
+        /// </summary>
+        public const string FriendsLocation = "friends_location";
+
+        /// <summary>
+        /// Provides access to the user's notes as the notes connection
+        /// </summary>
+        public const string FriendsNotes = "friends_notes";
+
+        /// <summary>
+        /// Provides access to the photos the user has uploaded, and photos the user has been tagged in
+        /// </summary>
+        public const string FriendsPhotos = "friends_photos";
+
+        /// <summary>
+        /// Provides access to the questions the user or friend has asked
+        /// </summary>
+        public const string FriendsQuestions = "friends_questions";
+
+        /// <summary>
+        /// Provides access to the user's family and personal relationships and relationship status
+        /// </summary>
+        public const string FriendsRelationships = "friends_relationships";
+
+        /// <summary>
+        /// Provides access to the user's relationship preferences
+        /// </summary>
+        public const string FriendsRelationshipDetails = "friends_relationship_details";
+
+        /// <summary>
+        /// Provides access to the user's religious and political affiliations
+        /// </summary>
+        public const string FriendsReligionPolitics = "friends_religion_politics";
+
+        /// <summary>
+        /// Provides access to the user's status messages and checkins. Please see the documentation for the location_post table for information on how this permission may affect retrieval of information about the locations associated with posts.
+        /// </summary>
+        public const string FriendsStatus = "friends_status";
+
+        /// <summary>
+        /// Provides access to the user's subscribers and subscribees
+        /// </summary>
+        public const string FriendsSubscriptions = "friends_subscriptions";
+
+        /// <summary>
+        /// Provides access to the videos the user has uploaded, and videos the user has been tagged in
+        /// </summary>
+        public const string FriendsVideos = "friends_videos";
+
+        /// <summary>
+        /// Provides access to the user's web site URL
+        /// </summary>
+        public const string FriendsWebsite = "friends_website";
+
+        /// <summary>
+        /// Provides access to work history as the work property
+        /// </summary>
+        public const string FriendsWorkHistory = "friends_work_history";
+
+        #endregion
+
+
+        #region Open Graph Permissions (User)
+
+        /// <summary>
+        /// Allows your app to publish to the Open Graph using Built-in Actions, Achievements, Scores, or Custom Actions. Your app can also publish other activity which is detailed in the Publishing Permissions doc. Note: The user-prompt for this permission will be displayed in the first screen of the Enhanced Auth Dialog and cannot be revoked as part of the authentication flow. However, a user can later revoke this permission in their Account Settings. If you want to be notified if this happens, you should subscribe to the permissions object within the Realtime API.
+        /// </summary>
+        public const string PublishActions = "publish_actions";
+
+        /// <summary>
+        /// Allows you to retrieve the actions published by all applications using the built-in music.listens action.
+        /// </summary>
+        public const string UserActionsMusic = "user_actions.music";
+
+        /// <summary>
+        /// Allows you to retrieve the actions published by all applications using the built-in news.reads action.
+        /// </summary>
+        public const string UserActionsNews = "user_actions.news";
+
+        /// <summary>
+        /// Allows you to retrieve the actions published by all applications using the built-in video.watches action.
+        /// </summary>
+        public const string UserActionsVideo = "user_actions.video";
+
+        /// <summary>
+        /// Allows you post and retrieve game achievement activity.
+        /// </summary>
+        public const string UserGamesActivity = "user_games_activity";
+
+        #endregion
+
+
+        #region Open Graph Permissions (Friend)
+
+        /// <summary>
+        /// Allows you to retrieve the actions published by all applications using the built-in music.listens action.
+        /// </summary>
+        public const string FriendsActionsMusic = "friends_actions.music";
+
+        /// <summary>
+        /// Allows you to retrieve the actions published by all applications using the built-in news.reads action.
+        /// </summary>
+        public const string FriendsActionsNews = "friends_actions.news";
+
+        /// <summary>
+        /// Allows you to retrieve the actions published by all applications using the built-in video.watches action.
+        /// </summary>
+        public const string FriendsActionsVideo = "friends_actions.video";
+
+        /// <summary>
+        /// Allows you post and retrieve game achievement activity.
+        /// </summary>
+        public const string FriendsGamesActivity = "friends_games_activity";
+
+        #endregion
+
+
+        #region Page Permissions
+
+        /// <summary>
+        /// Enables your application to retrieve access_tokens for Pages and Applications that the user administrates. The access tokens can be queried by calling /<user_id>/accounts via the Graph API. See here for generating long-lived Page access tokens that do not expire after 60 days.
+        /// </summary>
+        public const string ManagePages = "manage_pages";
+
+        #endregion
+
+
+        #region Public Profile and Friends List
+
+        public const string Id = "id";
+
+        public const string Name = "name";
+
+        public const string FirstName = "first_name";
+
+        public const string LastName = "last_name";
+
+        public const string Link = "link";
+
+        public const string Username = "username";
+
+        public const string Gender = "gender";
+
+        public const string Locale = "locale";
+
+        #endregion
+
+    }
+}

--- a/FluentACS/Specs/FacebookIdentityProviderSpec.cs
+++ b/FluentACS/Specs/FacebookIdentityProviderSpec.cs
@@ -1,4 +1,7 @@
-﻿namespace FluentACS.Specs
+﻿using System;
+using System.Collections.Generic;
+
+namespace FluentACS.Specs
 {
     public class FacebookIdentityProviderSpec : IdentityProviderSpec
     {
@@ -6,9 +9,12 @@
 
         private string appSecret;
 
+        private readonly List<string> applicationPermissions = new List<string>();
+
         public FacebookIdentityProviderSpec()
         {
             this.DisplayName(IdentityProviderConsts.Facebook);
+            this.applicationPermissions.Add("email");
         }
 
         public FacebookIdentityProviderSpec AppId(string appId)
@@ -23,6 +29,19 @@
             return this;
         }
 
+        public FacebookIdentityProviderSpec WithApplicationPermission(string permission)
+        {
+            Guard.NotNullOrEmpty(() => permission, permission);
+
+            if (applicationPermissions.Contains(permission.ToLowerInvariant()))
+            {
+                throw new InvalidOperationException(string.Format("The permission '{0}' already exists for the Facebook Identity provider.", permission));
+            }
+
+            this.applicationPermissions.Add(permission.ToLowerInvariant());
+            return this;
+        }
+
         internal string AppId()
         {
             return this.appId;
@@ -31,6 +50,11 @@
         internal string AppSecret()
         {
             return this.appSecret;
+        }
+
+        internal string[] ApplicationPermissions()
+        {
+            return this.applicationPermissions.ToArray();
         }
     }
 }

--- a/FluentACS/Specs/FacebookIdentityProviderSpec.cs
+++ b/FluentACS/Specs/FacebookIdentityProviderSpec.cs
@@ -1,0 +1,36 @@
+﻿namespace FluentACS.Specs
+{
+    public class FacebookIdentityProviderSpec : IdentityProviderSpec
+    {
+        private string appId;
+
+        private string appSecret;
+
+        public FacebookIdentityProviderSpec()
+        {
+            this.DisplayName(IdentityProviderConsts.Facebook);
+        }
+
+        public FacebookIdentityProviderSpec AppId(string appId)
+        {
+            this.appId = appId;
+            return this;
+        }
+
+        public FacebookIdentityProviderSpec AppSecret(string appSecret)
+        {
+            this.appSecret = appSecret;
+            return this;
+        }
+
+        internal string AppId()
+        {
+            return this.appId;
+        }
+
+        internal string AppSecret()
+        {
+            return this.appSecret;
+        }
+    }
+}

--- a/FluentACS/Specs/IdentityProviderConsts.cs
+++ b/FluentACS/Specs/IdentityProviderConsts.cs
@@ -7,5 +7,7 @@
         public const string Yahoo = "Yahoo!";
 
         public const string WindowsLive = "Windows Live ID";
+
+        public const string Facebook = "Facebook";
     }
 }

--- a/FluentACS/Specs/RelyingPartySpec.cs
+++ b/FluentACS/Specs/RelyingPartySpec.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Security.Cryptography.X509Certificates;
 
     using FluentACS.Commands;
     using FluentACS.ManagementService;
@@ -80,6 +81,14 @@
             Guard.NotNull(() => encryptionCert, encryptionCert);
 
             this.encryptionCert = encryptionCert;
+            return this;
+        }
+        
+        public RelyingPartySpec EncryptionCertificate(X509Certificate encryptionCert)
+        {
+            Guard.NotNull(() => encryptionCert, encryptionCert);
+
+            this.encryptionCert = encryptionCert.GetRawCertData();
             return this;
         }
 

--- a/FluentACS/Specs/RelyingPartySpec.cs
+++ b/FluentACS/Specs/RelyingPartySpec.cs
@@ -92,6 +92,21 @@
             return this;
         }
 
+        public RelyingPartySpec EncryptionCertificateIdentifiedBy(string thumbprint)
+        {
+            return EncryptionCertificateIdentifiedBy(thumbprint, StoreName.My, StoreLocation.CurrentUser);
+        }
+
+        public RelyingPartySpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName, StoreLocation storeLocation)
+        {
+            Guard.NotNullOrEmpty(() => thumbprint, thumbprint);
+
+            var certificate = X509CertificateHelper.GetX509Certificate(thumbprint, storeName, storeLocation);
+
+            this.encryptionCert = certificate.GetRawCertData();
+            return this;
+        }
+
         public RelyingPartySpec LinkToRuleGroup(string ruleGroupName)
         {
             Guard.NotNullOrEmpty(() => ruleGroupName, ruleGroupName);
@@ -230,5 +245,6 @@
         {
             return this.tokenLifetime;
         }
+
     }
 }

--- a/FluentACS/Specs/RelyingPartySpec.cs
+++ b/FluentACS/Specs/RelyingPartySpec.cs
@@ -92,12 +92,7 @@
             return this;
         }
 
-        public RelyingPartySpec EncryptionCertificateIdentifiedBy(string thumbprint)
-        {
-            return EncryptionCertificateIdentifiedBy(thumbprint, StoreName.My, StoreLocation.CurrentUser);
-        }
-
-        public RelyingPartySpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName, StoreLocation storeLocation)
+        public RelyingPartySpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
             Guard.NotNullOrEmpty(() => thumbprint, thumbprint);
 

--- a/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
+++ b/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
@@ -37,14 +37,8 @@ namespace FluentACS.Specs
 
         public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName, StoreLocation storeLocation)
         {
-            var store = new X509Store(storeName, storeLocation);
-            store.Open(OpenFlags.ReadOnly);
-            var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false);
-
-            if (certificates.Count == 0)
-                throw new ArgumentException(string.Format("Thumbprint {0} was not found in {1}//{2}", thumbprint, storeLocation, storeName), "thumbprint");
-
-            return this.EncryptionCertificate(certificates[0]);
+            var certificate = X509CertificateHelper.GetX509Certificate(thumbprint, storeName, storeLocation);
+            return this.EncryptionCertificate(certificate);
         }
 
         public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint)

--- a/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
+++ b/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
@@ -1,0 +1,64 @@
+using System;
+using FluentACS;
+
+namespace FluentACS.Specs
+{
+    public class ServiceIdentityWithX509CertificateSpec
+    {
+        private byte[] encryptionCert;
+
+        private string name;
+
+        private DateTime startDate;
+
+        private DateTime endDate;
+
+        public ServiceIdentityWithX509CertificateSpec Name(string name)
+        {
+            Guard.NotNullOrEmpty(() => name, name);
+
+            this.name = name;
+            return this;
+        }
+
+        public ServiceIdentityWithX509CertificateSpec EncryptionCertificate(byte[] encryptionCert)
+        {
+            Guard.NotNull(() => encryptionCert, encryptionCert);
+
+            this.encryptionCert = encryptionCert;
+            return this;
+        }
+
+        public ServiceIdentityWithX509CertificateSpec StartDate(DateTime startDate)
+        {
+            this.startDate = startDate;
+            return this;
+        }
+
+        public ServiceIdentityWithX509CertificateSpec EndDate(DateTime endDate)
+        {
+            this.endDate = endDate;
+            return this;
+        }
+
+        internal string Name()
+        {
+            return this.name;
+        }
+
+        internal byte[] EncryptionCertificate()
+        {
+            return this.encryptionCert;
+        }
+
+        internal DateTime StartDate()
+        {
+            return this.startDate;
+        }
+
+        internal DateTime EndDate()
+        {
+            return this.endDate;
+        }
+    }
+}

--- a/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
+++ b/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
@@ -3,6 +3,9 @@ using FluentACS;
 
 namespace FluentACS.Specs
 {
+    using System.IO;
+    using System.Security.Cryptography.X509Certificates;
+
     public class ServiceIdentityWithX509CertificateSpec
     {
         private byte[] encryptionCert;
@@ -27,6 +30,36 @@ namespace FluentACS.Specs
 
             this.encryptionCert = encryptionCert;
             return this;
+        }
+
+        public ServiceIdentityWithX509CertificateSpec EncryptionCertificate(string path)
+        {
+            Guard.NotNullOrEmpty(() => path, path);
+            Guard.FileExists(() => path, path);
+
+            var cert = new X509Certificate(path);
+            this.StartDate(DateTime.Parse(cert.GetEffectiveDateString()));
+            this.EndDate(DateTime.Parse(cert.GetExpirationDateString()));
+            return this.EncryptionCertificate(cert.GetRawCertData());
+        }
+
+        public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName, StoreLocation storeLocation)
+        {
+            var store = new X509Store(storeName, storeLocation);
+            store.Open(OpenFlags.ReadOnly);
+            var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false);
+
+            if (certificates.Count == 0)
+                throw new ArgumentException(string.Format("Thumbprint {0} was not found in {1}//{2}", thumbprint, storeLocation, storeName), "thumbprint");
+
+            this.StartDate(DateTime.Parse(certificates[0].GetEffectiveDateString()));
+            this.EndDate(DateTime.Parse(certificates[0].GetExpirationDateString()));
+            return this.EncryptionCertificate(certificates[0].GetRawCertData());
+        }
+
+        public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint)
+        {
+            return this.EncryptionCertificateIdentifiedBy(thumbprint, StoreName.My, StoreLocation.CurrentUser);
         }
 
         public ServiceIdentityWithX509CertificateSpec StartDate(DateTime startDate)

--- a/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
+++ b/FluentACS/Specs/ServiceIdentityWithX509CertificateSpec.cs
@@ -35,15 +35,10 @@ namespace FluentACS.Specs
             return this.EncryptionCertificate(new X509Certificate2(path));
         }
 
-        public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName, StoreLocation storeLocation)
+        public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint, StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
             var certificate = X509CertificateHelper.GetX509Certificate(thumbprint, storeName, storeLocation);
             return this.EncryptionCertificate(certificate);
-        }
-
-        public ServiceIdentityWithX509CertificateSpec EncryptionCertificateIdentifiedBy(string thumbprint)
-        {
-            return this.EncryptionCertificateIdentifiedBy(thumbprint, StoreName.My, StoreLocation.CurrentUser);
         }
 
         internal string Name()

--- a/FluentACS/Specs/X509CertificateHelper.cs
+++ b/FluentACS/Specs/X509CertificateHelper.cs
@@ -1,0 +1,25 @@
+namespace FluentACS.Specs
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+
+    public class X509CertificateHelper
+    {
+        public static X509Certificate2 GetX509Certificate(string thumbprint, StoreName storeName, StoreLocation storeLocation)
+        {
+            var store = new X509Store(storeName, storeLocation);
+            store.Open(OpenFlags.ReadOnly);
+            var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false);
+
+            if (certificates.Count == 0)
+            {
+                throw new ArgumentException(
+                    string.Format("Thumbprint {0} was not found in {1}//{2}", thumbprint, storeLocation, storeName),
+                    "thumbprint");
+            }
+
+            var certificate = certificates[0];
+            return certificate;
+        }
+    }
+}

--- a/FluentACSTest/App.config
+++ b/FluentACSTest/App.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <appSettings>
-        <add key="acsNamespace" value="fluentacsd6"/>
-        <add key="acsUserName" value="ManagementClient"/>
-        <add key="acsPassword" value="WBI6j+fRYIWiiVMImZllDGqVh9NIDfcnjrdHJTvsQLg="/>
-    </appSettings>
+  <appSettings>
+    <add key="acsNamespace" value="fluentacsd6"/>
+    <add key="acsUserName" value="ManagementClient"/>
+    <add key="acsPassword" value="WBI6j+fRYIWiiVMImZllDGqVh9NIDfcnjrdHJTvsQLg="/>
+    <add key="facebookAppId" value="104742876371229"/>
+    <add key="facebookAppSecret" value="f6a532bdbd45218267c365183825463b"/>
+    <add key="facebookAppNamespace" value="fluentacstestdsix"/>
+  </appSettings>
 </configuration>

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -48,6 +48,25 @@
         }
 
         [TestMethod]
+        public void AddVandelayIndustriesServiceIdentityWithX509()
+        {
+            var encryptionCert = new X509Certificate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));
+            var acsNamespace = new AcsNamespace(namespaceDesc);
+            var name = "Vandelay Industries X509";
+
+            acsNamespace.AddServiceIdentityWithX509Certificate(
+                si => si
+                    .Name(name)
+                    .EncryptionCertificate(encryptionCert.GetRawCertData())
+                    .StartDate(DateTime.Parse(encryptionCert.GetEffectiveDateString()))
+                    .EndDate(DateTime.Parse(encryptionCert.GetExpirationDateString())));
+
+            acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
+
+            Assert.IsTrue(AcsHelper.CheckServiceIdentityExists(this.namespaceDesc, name));
+        }
+
+        [TestMethod]
         public void AddMyCoolWebsiteRelyingParty()
         {
             var acsNamespace = new AcsNamespace(this.namespaceDesc);

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -106,6 +106,37 @@
         }
 
         [TestMethod]
+        public void AddVandelayIndustriesServiceIdentityWithX509FromFile()
+        {
+            var encryptionCert = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer");
+            var acsNamespace = new AcsNamespace(namespaceDesc);
+            var name = "Vandelay Industries X509";
+
+            acsNamespace.AddServiceIdentityWithX509Certificate(
+                si => si
+                    .Name(name).EncryptionCertificate(encryptionCert));
+
+            acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
+
+            Assert.IsTrue(AcsHelper.CheckServiceIdentityExists(this.namespaceDesc, name));
+        }
+
+        [TestMethod]
+        public void AddVandelayIndustriesServiceIdentityWithX509FromStore()
+        {
+            var acsNamespace = new AcsNamespace(namespaceDesc);
+            var name = "Vandelay Industries X509";
+
+            acsNamespace.AddServiceIdentityWithX509Certificate(
+                si => si
+                    .Name(name).EncryptionCertificateIdentifiedBy("66e0bc68570e30fba6207b1050ac72dc5b48cf47"));
+
+            acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
+
+            Assert.IsTrue(AcsHelper.CheckServiceIdentityExists(this.namespaceDesc, name));
+        }
+
+        [TestMethod]
         public void AddMyCoolWebsiteRelyingParty()
         {
             var acsNamespace = new AcsNamespace(this.namespaceDesc);

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -130,7 +130,7 @@
 
             acsNamespace.AddServiceIdentityWithX509Certificate(
                 si => si
-                    .Name(name).EncryptionCertificateIdentifiedBy("66e0bc68570e30fba6207b1050ac72dc5b48cf47"));
+                    .Name(name).EncryptionCertificateIdentifiedBy(thumbprint: "66e0bc68570e30fba6207b1050ac72dc5b48cf47"));
 
             acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
 
@@ -210,7 +210,6 @@
         public void AddMyCoolWebsiteRelyingPartyWithSamlTokenDetailsWithX509CertificateFromFile()
         {
             var encryptionCert = new X509Certificate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));
-            var temp = new X509Certificate2(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert_xyz.pfx"), "xyz");
 
             var acsNamespace = new AcsNamespace(this.namespaceDesc);
             acsNamespace.AddRelyingParty(
@@ -220,6 +219,25 @@
                     .ReplyAddress("http://mycoolwebsitewithx509.com/")
                     .AllowGoogleIdentityProvider()
                     .EncryptionCertificate(encryptionCert));
+
+            acsNamespace.SaveChanges();
+
+            Assert.IsTrue(AcsHelper.CheckRelyingPartyExists(this.namespaceDesc, "MyCoolWebsite with X509"));
+            Assert.IsTrue(AcsHelper.CheckRelyingPartyHasKeys(this.namespaceDesc, "MyCoolWebsite with X509", 1));
+        }
+
+        [TestMethod]
+        [DeploymentItem("testCert.cer")]
+        public void AddMyCoolWebsiteRelyingPartyWithSamlTokenDetailsWithX509CertificateFromCertificateStore()
+        {
+            var acsNamespace = new AcsNamespace(this.namespaceDesc);
+            acsNamespace.AddRelyingParty(
+                rp => rp
+                    .Name("MyCoolWebsite with X509")
+                    .RealmAddress("http://mycoolwebsitewithx509.com/")
+                    .ReplyAddress("http://mycoolwebsitewithx509.com/")
+                    .AllowGoogleIdentityProvider()
+                    .EncryptionCertificateIdentifiedBy(thumbprint: "66e0bc68570e30fba6207b1050ac72dc5b48cf47"));
 
             acsNamespace.SaveChanges();
 

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -87,6 +87,7 @@
         }
 
         [TestMethod]
+        [DeploymentItem("testCert.cer")]
         public void AddVandelayIndustriesServiceIdentityWithX509()
         {
             var encryptionCert = new X509Certificate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));
@@ -106,6 +107,7 @@
         }
 
         [TestMethod]
+        [DeploymentItem("testCert.cer")]
         public void AddVandelayIndustriesServiceIdentityWithX509FromFile()
         {
             var encryptionCert = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer");
@@ -175,6 +177,8 @@
         }
 
         [TestMethod]
+        [DeploymentItem("testCert_xyz.pfx")]
+        [DeploymentItem("testCert.cer")]
         public void AddMyCoolWebsiteRelyingPartyWithSamlTokenDetails()
         {
             var encryptionCert = new X509Certificate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -206,7 +206,6 @@
         }
 
         [TestMethod]
-        [DeploymentItem("testCert_xyz.pfx")]
         [DeploymentItem("testCert.cer")]
         public void AddMyCoolWebsiteRelyingPartyWithSamlTokenDetailsWithX509CertificateFromFile()
         {

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -90,16 +90,15 @@
         [DeploymentItem("testCert.cer")]
         public void AddVandelayIndustriesServiceIdentityWithX509()
         {
-            var encryptionCert = new X509Certificate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));
+            var encryptionCert = new X509Certificate2(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));
             var acsNamespace = new AcsNamespace(namespaceDesc);
             var name = "Vandelay Industries X509";
 
             acsNamespace.AddServiceIdentityWithX509Certificate(
                 si => si
                     .Name(name)
-                    .EncryptionCertificate(encryptionCert.GetRawCertData())
-                    .StartDate(DateTime.Parse(encryptionCert.GetEffectiveDateString()))
-                    .EndDate(DateTime.Parse(encryptionCert.GetExpirationDateString())));
+                    .EncryptionCertificate(encryptionCert)
+                );
 
             acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
 

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -19,6 +19,10 @@
             ConfigurationManager.AppSettings["acsUserName"],
             ConfigurationManager.AppSettings["acsPassword"]);
 
+        private readonly string facebookAppId = ConfigurationManager.AppSettings["facebookAppId"];
+
+        private readonly string facebookAppSecret = ConfigurationManager.AppSettings["facebookAppSecret"];
+
         [TestMethod]
         public void AddGoogleAndYahooIdentityProviders()
         {
@@ -31,6 +35,22 @@
 
             Assert.IsTrue(AcsHelper.CheckIdentityProviderExists(this.namespaceDesc, "Google"));
             Assert.IsTrue(AcsHelper.CheckIdentityProviderExists(this.namespaceDesc, "Yahoo!"));
+        }
+
+        [TestMethod]
+        public void AddFacebookIdentityProvider()
+        {
+            var acsNamespace = new AcsNamespace(this.namespaceDesc);
+            acsNamespace
+                .AddFacebookIdentityProvider(
+                    ip => ip
+                        .AppId(facebookAppId)
+                        .AppSecret(facebookAppSecret)
+                );
+
+            acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
+
+            Assert.IsTrue(AcsHelper.CheckIdentityProviderExists(this.namespaceDesc, "Facebook"));
         }
 
         [TestMethod]
@@ -236,6 +256,8 @@
             Assert.IsTrue(AcsHelper.CheckRelyingPartyExists(this.namespaceDesc, "MyCoolWebsite"));
         }
 
+        #region Helpers
+
         public byte[] ReadBytesFromPfxFile(string pfxFileName)
         {
             byte[] signingCertificate;
@@ -249,5 +271,7 @@
 
             return signingCertificate;
         }
+
+        #endregion
     }
 }

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -206,6 +206,29 @@
         }
 
         [TestMethod]
+        [DeploymentItem("testCert_xyz.pfx")]
+        [DeploymentItem("testCert.cer")]
+        public void AddMyCoolWebsiteRelyingPartyWithSamlTokenDetailsWithX509CertificateFromFile()
+        {
+            var encryptionCert = new X509Certificate(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert.cer"));
+            var temp = new X509Certificate2(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "testCert_xyz.pfx"), "xyz");
+
+            var acsNamespace = new AcsNamespace(this.namespaceDesc);
+            acsNamespace.AddRelyingParty(
+                rp => rp
+                    .Name("MyCoolWebsite with X509")
+                    .RealmAddress("http://mycoolwebsitewithx509.com/")
+                    .ReplyAddress("http://mycoolwebsitewithx509.com/")
+                    .AllowGoogleIdentityProvider()
+                    .EncryptionCertificate(encryptionCert));
+
+            acsNamespace.SaveChanges();
+
+            Assert.IsTrue(AcsHelper.CheckRelyingPartyExists(this.namespaceDesc, "MyCoolWebsite with X509"));
+            Assert.IsTrue(AcsHelper.CheckRelyingPartyHasKeys(this.namespaceDesc, "MyCoolWebsite with X509", 1));
+        }
+
+        [TestMethod]
         public void AddMyCoolWebsiteRelyingPartyWithRuleGroup()
         {
             var acsNamespace = new AcsNamespace(this.namespaceDesc);

--- a/FluentACSTest/IntegrationTests.cs
+++ b/FluentACSTest/IntegrationTests.cs
@@ -10,6 +10,7 @@
 
     using Microsoft.IdentityModel.Claims;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using FluentACS.Specs;
 
     [TestClass]
     public class IntegrationTests
@@ -46,6 +47,24 @@
                     ip => ip
                         .AppId(facebookAppId)
                         .AppSecret(facebookAppSecret)
+                );
+
+            acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));
+
+            Assert.IsTrue(AcsHelper.CheckIdentityProviderExists(this.namespaceDesc, "Facebook"));
+        }
+
+        [TestMethod]
+        public void AddFacebookIdentityProviderWithAdditionalPermissions()
+        {
+            var acsNamespace = new AcsNamespace(this.namespaceDesc);
+            acsNamespace
+                .AddFacebookIdentityProvider(
+                    ip => ip
+                        .AppId(facebookAppId)
+                        .AppSecret(facebookAppSecret)
+                        .WithApplicationPermission(FacebookApplicationPermission.UserPhotos)
+                        .WithApplicationPermission(FacebookApplicationPermission.PublishStream)
                 );
 
             acsNamespace.SaveChanges(logInfo => Trace.WriteLine(logInfo.Message));


### PR DESCRIPTION
- Added AddServiceIdentityWithX509Certificate to AcsNamespace
  - Support for the following parameters
    - Name
    - EncryptionCertificate (Raw Byte[] of X509)
    - StartDate
    - EndDate
  - Supports following certificate locations
    - Local Store (User or Machine)
    - Local File System
    - In Memory Certificate Bytes
  - Added underlying support to ServiceManagementWrapper
  - Added test to prove operation
- Added support for a Facebook Identity Provider
  - Including support for application permissions
